### PR TITLE
feat: Implement draw names functionality

### DIFF
--- a/app/api/gift-exchanges/[id]/draw/route.ts
+++ b/app/api/gift-exchanges/[id]/draw/route.ts
@@ -1,0 +1,45 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { drawGiftExchange } from "@/lib/drawGiftExchange";
+
+/**
+ * API Route for drawing gift exchange names
+ * POST /api/gift-exchanges/[id]/draw
+ */
+
+export async function POST(
+  req: Request,
+  props: { params: Promise<{ id: string }> }
+) {
+  const params = await props.params;
+  const id = await params.id;
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await drawGiftExchange(supabase, id);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    let status = 500; // default status
+    if (message.includes("not found")) {
+      status = 404;
+    } else if (
+      message.includes("already been drawn") ||
+      message.includes("3 members")
+    ) {
+      status = 400;
+    }
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/lib/drawGiftExchange.ts
+++ b/lib/drawGiftExchange.ts
@@ -1,0 +1,76 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+
+// util function to draw gift exchange names
+// this function can be called from an API route
+// or from a scheduled job
+export async function drawGiftExchange(
+  supabase: SupabaseClient,
+  exchangeId: string
+) {
+  // Get exchange and verify ownership
+  const { data: exchange, error: exchangeError } = await supabase
+    .from("gift_exchanges")
+    .select("*")
+    .eq("id", exchangeId)
+    .single();
+
+  if (exchangeError || !exchange) {
+    throw new Error("Gift exchange not found");
+  }
+
+  // Check exchange status
+  if (exchange.status !== "pending") {
+    throw new Error("Names have already been drawn");
+  }
+
+  // Get all members
+  const { data: members, error: membersError } = await supabase
+    .from("gift_exchange_members")
+    .select("id, user_id")
+    .eq("gift_exchange_id", exchangeId);
+
+  if (membersError || !members) {
+    throw new Error("Failed to fetch members");
+  }
+
+  //Validate minimum members
+  if (members.length < 3) {
+    throw new Error("At least 3 members are required");
+  }
+
+  // Shuffle members to assign
+  const shuffledMembers = [...members].sort(() => Math.random() - 0.5);
+
+  // Update assignments
+  for (let i = 0; i < shuffledMembers.length; i++) {
+    const giver = shuffledMembers[i];
+    // Last person gives to first person, closing the circle
+    const recipient = shuffledMembers[(i + 1) % shuffledMembers.length];
+
+    const { error: updateError } = await supabase
+      .from("gift_exchange_members")
+      .update({
+        recipient_id: recipient.user_id,
+        has_drawn: true,
+      })
+      .eq("id", giver.id);
+
+    if (updateError) {
+      throw new Error("Failed to assign recipients");
+    }
+
+    // TODO: Generate giftExchange for each user
+  }
+
+  // Update exchange status to active
+  const { error: statusError } = await supabase
+    .from("gift_exchanges")
+    .update({ status: "active" })
+    .eq("id", exchangeId);
+
+  if (statusError) {
+    throw new Error("Failed to update exchange status");
+  }
+
+  return { success: true };
+}


### PR DESCRIPTION
This PR implements the **first pass** of the draw names backend functionality.

Psuedo code below:
1. Get GiftExchange from DB
2. Validate that its in "pending"
3. Get all members in the gift exchange
4. randomize them 
5. loop through member list and assign to the next person (its random)

TODO: We should start assigning the users in this age but I'll work on this in a separate PR




You can call it in FE like below:
```
fetch('/api/gift-exchanges/8e3f26aa-59c6-49a1-bc76-91c956f59c01/draw', {
  method: 'POST',
  headers: {
    'Content-Type': 'application/json'
  }
})
.then(response => response.json())
.then(data => console.log('Response:', data))
.catch(error => console.error('Error:', error));
```

<img width="781" alt="Screenshot 2024-12-19 at 10 13 34 PM" src="https://github.com/user-attachments/assets/c5ab3bff-b46d-4c61-9a04-ab7ac47c9014" />
