### PR TITLE
fix:#292 address ESlint issues for getUserAvatar component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -55,7 +55,5 @@ components/SnowOverlayWrapper/react-snow-overlay.d.ts
 lib/drawGiftExchange.ts
 lib/generateAndStoreSuggestions.ts
 lib/getAmazonImage.ts
-lib/getUserAvatar.ts
-lib/getUserAvatar.ts
 lib/supabase/middleware.ts
 lib/utils.ts

--- a/lib/getUserAvatar.ts
+++ b/lib/getUserAvatar.ts
@@ -1,4 +1,13 @@
-const getUserAvatar = async () => {
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+/**
+ * Asynchronously fetches the current user's avatar data (url) from the API.
+ * Sends a GET request to the '/api/getUserAvatar' endpoint and returns the
+ * parsed JSON response containing the user's avatar information (url).
+ * @returns {Promise<string>} - A promise that resolves to the user's avatar url.
+ */
+const getUserAvatar = async (): Promise<string> => {
   const response = await fetch('api/getUserAvatar', {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Description
### Before: 
There were three linting errors: header missing, return type missing, and JSDoc missing

### After: 
I addressed the ESlint errors by adding a header, JSDoc comments and an explicit return type. I set the return type to `Promise<string>` because while the inferred type is `Promise<any`, the consuming component, UserDropdownMenu, expects a `string` return value.

<!-- Example: closes #123 -->
 Closes #292 
 
## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`