### PR TITLE
fix:#664 Fix failing tests in CreateGroup page and EditGroup page

### DIFF
--- a/app/create-group-page/page.test.tsx
+++ b/app/create-group-page/page.test.tsx
@@ -22,9 +22,18 @@ global.ResizeObserver = MockResizeObserver;
 
 describe('Create Group Page', () => {
   describe('Calendar component in create group page', () => {
-    it('disables past dates correctly', () => {
-      const currentDate = new Date('2025-10-08T00:00:00Z');
+    const currentDate = new Date('2025-10-15T00:00:00Z');
 
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(currentDate);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('disables past dates correctly', () => {
       render(
         <Calendar
           mode="single"
@@ -35,13 +44,13 @@ describe('Create Group Page', () => {
         />,
       );
 
-      const pastDate = screen.getByText('5');
+      const pastDate = screen.getByText('13');
       expect(pastDate).toBeDisabled();
 
-      const today = screen.getByText('8');
+      const today = screen.getByText('15');
       expect(today).not.toBeDisabled();
 
-      const tomorrow = screen.getByText('9');
+      const tomorrow = screen.getByText('16');
       expect(tomorrow).not.toBeDisabled();
     });
   });

--- a/app/gift-exchanges/[id]/edit/page.test.tsx
+++ b/app/gift-exchanges/[id]/edit/page.test.tsx
@@ -2,9 +2,18 @@ import { Calendar } from '@/components/Calendar/calendar';
 import { render, screen } from '@testing-library/react';
 
 describe('Calendar component in create group page', () => {
-  it('disables past dates correctly', () => {
-    const currentDate = new Date('2025-10-08T00:00:00Z');
+  const currentDate = new Date('2025-10-15T00:00:00Z');
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(currentDate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('disables past dates correctly', () => {
     render(
       <Calendar
         mode="single"
@@ -15,13 +24,13 @@ describe('Calendar component in create group page', () => {
       />,
     );
 
-    const pastDate = screen.getByText('5');
+    const pastDate = screen.getByText('13');
     expect(pastDate).toBeDisabled();
 
-    const today = screen.getByText('8');
+    const today = screen.getByText('15');
     expect(today).not.toBeDisabled();
 
-    const tomorrow = screen.getByText('9');
+    const tomorrow = screen.getByText('16');
     expect(tomorrow).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Description

### Before: 
Two unit tests were failing because they were reliant on the actual system date.

### After: 
The date for the tests is now mocked and the Calendar component will be rendered consistently in these tests.

<!-- Example: closes #123 -->
 Closes #664

## Additional information
Moved the `past`, `today`, and `tomorrow` dates to the middle of the month to avoid the potential duplicate days that may occur near the beginning and end of the calendar display.

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`