### PR TITLE
Fix: added `beta` into the logo

### DIFF
--- a/app/assets/svgs/LogoCombination.tsx
+++ b/app/assets/svgs/LogoCombination.tsx
@@ -140,10 +140,10 @@ const LogoCombination: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
         id="path24"
       />
       <text
-        x="248"
-        y="60"
-        fill="#FAB76A"
-        fontSize="24"
+        x="340"
+        y="55"
+        fill="#ffffff"
+        fontSize="16"
         fontFamily="Arial, sans-serif"
       >
         BETA


### PR DESCRIPTION
## Description

### Before: 
Didn't have `beta` in the logo

### After: 
Now has the word `beta` in it to let user's know we are in the beta phase.

<!-- Example: closes #123 -->
 Closes #673 
 
<img width="386" height="77" alt="image" src="https://github.com/user-attachments/assets/d2023416-f544-491b-9e43-0e725c259ab5" />

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`