### PR TITLE
fix:#653 Remove default dates from CreateGroup and EditGroup pages day picker

### DIFF
--- a/app/create-group-page/page.test.tsx
+++ b/app/create-group-page/page.test.tsx
@@ -4,7 +4,6 @@
 import { render, screen } from '@testing-library/react';
 import CreateGroupPage from './page';
 import { Calendar } from '@/components/Calendar/calendar';
-import userEvent from '@testing-library/user-event';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -52,18 +51,20 @@ describe('Create Group Page', () => {
         );
       });
     });
-  const currentDate = new Date('2025-10-15T18:00:00Z');
-
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(currentDate);
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   describe('Calendar component in create group page', () => {
+    const currentDate = new Date('2025-10-15T00:00:00Z');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(currentDate);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('disables past dates correctly', () => {
       render(
         <Calendar
@@ -85,35 +86,4 @@ describe('Create Group Page', () => {
       expect(tomorrow).not.toBeDisabled();
     });
   });
-  
-  it('has the first group image selected by default', () => {
-    render(<CreateGroupPage />);
-    
-    const [firstTile, ...otherTiles] = screen.getAllByRole('figure');
-    expect(firstTile).toHaveAttribute('data-state', 'checked');
-    otherTiles.forEach((imageTile) => {
-      expect(imageTile).toHaveAttribute('data-state', 'unchecked');
-    });
-  });
-  
-  it('does not show a validation error for the Calendar input when the user clicks on the default date and tries to submit the form', async () => {
-    render(<CreateGroupPage />);
-
-    jest.useRealTimers();
-    
-    const user = userEvent.setup()
-
-    // const drawingDateButton1 = screen.getAllByTestId('popover-trigger')[1]
-    // console.log(drawingDateButton1.length)
-    const drawingDateButton = screen.getByLabelText('Gift Drawing Date')
-    const submitButton = screen.getByRole('button',{name: 'Create Group'})
-    expect(drawingDateButton).toBeInTheDocument()
-    // // console.log(drawingDateButton)
-    await user.click(drawingDateButton) // need realTimers here
-    const today = screen.getByText('15');
-    await user.click(today)
-    await user.click(submitButton)
-    screen.debug(undefined, Infinity)
-    // expect(errorMessage).toBeInTheDocument()
-  })
-  })})
+});

--- a/app/create-group-page/page.tsx
+++ b/app/create-group-page/page.tsx
@@ -23,7 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/Popover/popover';
-import { format } from 'date-fns';
+import { addDays, format } from 'date-fns';
 import {
   Command,
   CommandEmpty,
@@ -85,8 +85,8 @@ export default function CreateGroupPage() {
     defaultValues: {
       name: '',
       description: '',
-      drawing_date: new Date(),
-      exchange_date: new Date(),
+      drawing_date: undefined,
+      exchange_date: undefined,
       budget: '',
       group_image: GROUP_IMAGES[0].src,
     },
@@ -111,7 +111,6 @@ export default function CreateGroupPage() {
   }
 
   const giftDrawingDate = form.watch('drawing_date');
-  console.log(giftDrawingDate)
 
   return (
     <div className="create-group-page flex justify-center align-center flex-col px-4 md:px-16 lg:px-32 xl:px-52 pt-12">
@@ -282,8 +281,7 @@ export default function CreateGroupPage() {
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          // onSelect={(e)=> {if (e) field.onChange(e); console.log(e)}}
-                          disabled={[{ before: new Date() }]} //
+                          disabled={[{ before: new Date() }]} 
                           initialFocus
                         />
                       </PopoverContent>
@@ -327,7 +325,7 @@ export default function CreateGroupPage() {
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          disabled={[{ before: giftDrawingDate }]}
+                          disabled={[{ before: addDays(new Date(giftDrawingDate), 1) }]}
                           initialFocus
                         />
                       </PopoverContent>

--- a/app/gift-exchanges/[id]/edit/page.tsx
+++ b/app/gift-exchanges/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/Popover/popover';
-import { format } from 'date-fns';
+import { addDays, format } from 'date-fns';
 import {
   Command,
   CommandEmpty,
@@ -96,8 +96,8 @@ export default function EditGroupPage() {
     defaultValues: {
       name: '',
       description: '',
-      drawing_date: new Date(),
-      exchange_date: new Date(),
+      drawing_date: undefined,
+      exchange_date: undefined,
       budget: '',
       group_image: '',
     },
@@ -388,7 +388,7 @@ export default function EditGroupPage() {
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          disabled={[{ before: giftDrawingDate }]}
+                          disabled={[{ before: addDays(new Date(giftDrawingDate), 1) }]}
                           initialFocus
                         />
                       </PopoverContent>


### PR DESCRIPTION
## Description

### Before: 
Having a pre-defined default date led to a bug where clicking on the same day (today) would set the form state for that date picker / form field to `undefined` instead of the correct date.

### After: 
Removed the default date in the form state for both the Drawing Date and the Exchange Date. Now the form cannot be submitted without a date being selected.

Also, improved the behavior of the Exchange Date picker so that "today" is disabled; "tomorrow" is the first choice that is enabled. 

<!-- Example: closes #123 -->
 Closes #653

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`