### PR TITLE
Fix: awaiting function for gift generation

### DIFF
--- a/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
@@ -191,6 +191,8 @@ describe('GiftExchangeHeader owner permissions', () => {
     })
   });
 
+  it('should disable the draw gift exchange button when call() is running', async () => {});
+
   it('should render the complete gift exchange button when user_id and owner_id match', async () => {
     
     render(

--- a/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
@@ -191,7 +191,16 @@ describe('GiftExchangeHeader owner permissions', () => {
     })
   });
 
-  it('should disable the draw gift exchange button when gift exchange is being drawn', async () => {});
+  it('should disable the draw gift exchange button when gift exchange is being drawn', async () => {
+    
+    render(
+      <GiftExchangeHeader
+      giftExchangeData={mockGiftExchangeDataPending}
+      members={mockMembersData}
+      id={mockGiftExchangeDataPending.id} 
+      />
+    );
+  });
 
   it('should render the complete gift exchange button when user_id and owner_id match', async () => {
     

--- a/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
@@ -191,8 +191,8 @@ describe('GiftExchangeHeader owner permissions', () => {
     })
   });
 
-  it('should disable the draw gift exchange button when gift exchange is being drawn', async () => {
-    
+  it('should disable the draw gift exchange button when the gift exchange is being drawn', async () => {
+
     render(
       <GiftExchangeHeader
       giftExchangeData={mockGiftExchangeDataPending}

--- a/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.test.tsx
@@ -191,7 +191,7 @@ describe('GiftExchangeHeader owner permissions', () => {
     })
   });
 
-  it('should disable the draw gift exchange button when call() is running', async () => {});
+  it('should disable the draw gift exchange button when gift exchange is being drawn', async () => {});
 
   it('should render the complete gift exchange button when user_id and owner_id match', async () => {
     

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -239,13 +239,13 @@ export const GiftExchangeHeader = ({
             <div>
               {getStatusText(giftExchangeData.status) === 'Active' &&
                 isOwner && (
-                  <Button
-                    onClick={completeGiftExchange}
-                    data-testid="complete-gift-exchange"
-                  >
-                    Complete Gift Exchange
-                  </Button>
-                )}
+                <Button
+                  onClick={completeGiftExchange}
+                  data-testid="complete-gift-exchange"
+                >
+                  Complete Gift Exchange
+                </Button>
+              )}
               {getStatusText(giftExchangeData.status) === 'Open' && isOwner ? (
                 <AlertDialog>
                   <AlertDialogTrigger asChild>

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -32,6 +32,9 @@ import { Button } from '@/components/Button/button';
 import LinkCustom from '../LinkCustom/LinkCustom';
 import Image from 'next/image';
 import { GROUP_IMAGES } from '@/components/ImageSelector/ImageSelector';
+import { LoadingSpinner } from '../LoadingSpinner/LoadingSpinner';
+import { useToast } from '@/hooks/use-toast';
+import { ToastVariants } from '../Toast/Toast.enum';
 // initialize type for exchange data response
 
 interface MembersListProps {
@@ -60,6 +63,7 @@ export const GiftExchangeHeader = ({
 }: GiftExchangeHeaderPropsUnion): JSX.Element => {
   const [membersData, setMembersData] = useState(members);
   const [isDrawing, setIsDrawing] = useState(false);
+  const { toast } = useToast();
 
   useEffect(() => {
     setMembersData(members);
@@ -130,6 +134,13 @@ export const GiftExchangeHeader = ({
    */
   const call = async (): Promise<void> => {
     setIsDrawing(true);
+
+    toast({
+      variant: ToastVariants.Error,
+      title: 'Text goes here',
+      description: 'Text goes here',
+    });
+
     try {
       const response = await fetch(`/api/gift-exchanges/${id}/draw`, {
         method: 'POST',
@@ -228,21 +239,22 @@ export const GiftExchangeHeader = ({
             <div>
               {getStatusText(giftExchangeData.status) === 'Active' &&
                 isOwner && (
-                <Button
-                  onClick={completeGiftExchange}
-                  data-testid="complete-gift-exchange"
-                >
-                  Complete Gift Exchange
-                </Button>
-              )}
+                  <Button
+                    onClick={completeGiftExchange}
+                    data-testid="complete-gift-exchange"
+                  >
+                    Complete Gift Exchange
+                  </Button>
+                )}
               {getStatusText(giftExchangeData.status) === 'Open' && isOwner ? (
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
                     <Button
                       disabled={membersData.length <= 2 || isDrawing}
                       data-testid="draw-gift-exchange"
+                      className="min-w-40"
                     >
-                      {isDrawing ? "Drawing..." : "Draw Gift Exchange"}
+                      {isDrawing ? <LoadingSpinner /> : 'Draw Gift Exchange'}
                     </Button>
                   </AlertDialogTrigger>
                   {membersData.length <= 2 && (

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -161,6 +161,7 @@ export const GiftExchangeHeader = ({
       location.reload();
     } catch (error) {
       console.error('Failed to draw gift exchange:', error);
+    } finally {
       setIsDrawing(false);
     }
   };

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -59,6 +59,7 @@ export const GiftExchangeHeader = ({
   id,
 }: GiftExchangeHeaderPropsUnion): JSX.Element => {
   const [membersData, setMembersData] = useState(members);
+  const [isDrawing, setIsDrawing] = useState(false);
 
   useEffect(() => {
     setMembersData(members);
@@ -128,6 +129,7 @@ export const GiftExchangeHeader = ({
    * @returns {Promise<void>}
    */
   const call = async (): Promise<void> => {
+    setIsDrawing(true);
     try {
       const response = await fetch(`/api/gift-exchanges/${id}/draw`, {
         method: 'POST',
@@ -148,6 +150,7 @@ export const GiftExchangeHeader = ({
       location.reload();
     } catch (error) {
       console.error('Failed to draw gift exchange:', error);
+      setIsDrawing(false);
     }
   };
 
@@ -223,16 +226,23 @@ export const GiftExchangeHeader = ({
               <p className="text-xs">{giftExchangeData.description}</p>
             </div>
             <div>
-              {getStatusText(giftExchangeData.status) === 'Active' && isOwner && (
-                <Button onClick={completeGiftExchange} data-testid='complete-gift-exchange'>
+              {getStatusText(giftExchangeData.status) === 'Active' &&
+                isOwner && (
+                <Button
+                  onClick={completeGiftExchange}
+                  data-testid="complete-gift-exchange"
+                >
                   Complete Gift Exchange
                 </Button>
               )}
               {getStatusText(giftExchangeData.status) === 'Open' && isOwner ? (
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
-                    <Button disabled={membersData.length <= 2} data-testid='draw-gift-exchange'>
-                      Draw Gift Exchange
+                    <Button
+                      disabled={membersData.length <= 2 || isDrawing}
+                      data-testid="draw-gift-exchange"
+                    >
+                      {isDrawing ? "Drawing..." : "Draw Gift Exchange"}
                     </Button>
                   </AlertDialogTrigger>
                   {membersData.length <= 2 && (

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -136,9 +136,9 @@ export const GiftExchangeHeader = ({
     setIsDrawing(true);
 
     toast({
-      variant: ToastVariants.Error,
-      title: 'Text goes here',
-      description: 'Text goes here',
+      variant: ToastVariants.Success,
+      title: '',
+      description: 'Please keep this browser open until our elves complete the gift drawing.',
     });
 
     try {

--- a/components/GiftExchangeHeader/GiftExchangeHeader.tsx
+++ b/components/GiftExchangeHeader/GiftExchangeHeader.tsx
@@ -161,6 +161,11 @@ export const GiftExchangeHeader = ({
       location.reload();
     } catch (error) {
       console.error('Failed to draw gift exchange:', error);
+      toast({
+        variant: ToastVariants.Error,
+        title: 'Draw Failed',
+        description: 'Failed to complete the gift drawing. Please try again.',
+      });
     } finally {
       setIsDrawing(false);
     }

--- a/lib/drawGiftExchange.ts
+++ b/lib/drawGiftExchange.ts
@@ -94,15 +94,13 @@ export async function drawGiftExchange(
       // Fire and forget suggestions with error handling
       // hacky way to avoid waiting for all suggestions to be generated
       // avoids timeout issues
-      generateAndStoreSuggestions(
+      await generateAndStoreSuggestions(
         supabase,
         exchangeId,
         giver.user_id,
         recipient.user_id,
         exchange.budget,
-      ).catch((error) => {
-        throw new SupabaseError('Failed to generate suggestions', 500, error);
-      });
+      );
     }
 
     // Update exchange status to active

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.2-alpha",
   "private": true,
   "scripts": {
-    "dev": "cross-env PORT=4000 next dev",
+    "dev": "cross-env PORT=4000 NODE_OPTIONS=\"--inspect\" next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.2-alpha",
   "private": true,
   "scripts": {
-    "dev": "cross-env PORT=4000 NODE_OPTIONS=\"--inspect\" next dev",
+    "dev": "cross-env PORT=4000 next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Description

### After: 
Button disabled for gift drawing now with toast notification

<!-- Example: closes #123 -->
 Closes #[ticketnumber]

## [optional] Screenshots

https://github.com/user-attachments/assets/f8629f6a-20a2-4bd3-a37a-eabeaa7125db

## Pre-submission checklist

- [ ] Code builds and passes locally
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [ ] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [ ] Thread has been created in Discord and PR is linked in `gis-code-questions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loading state with spinner and disabled button while a gift exchange draw runs
  * Toast notifications informing users to keep their browser open during the draw and reporting success/failure

* **Bug Fixes**
  * Drawing workflow now surfaces errors reliably (sequential handling instead of fire-and-forget)

* **Tests**
  * Added a test case for disabling the draw button when a draw is in progress<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub><sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->