### PR TITLE
fix:#681 Added cancel buttons on Edit Group page

### DIFF
--- a/app/gift-exchanges/[id]/edit/page.test.tsx
+++ b/app/gift-exchanges/[id]/edit/page.test.tsx
@@ -1,36 +1,99 @@
 import { Calendar } from '@/components/Calendar/calendar';
 import { render, screen } from '@testing-library/react';
+import EditGroupPage from './page';
 
-describe('Calendar component in create group page', () => {
-  const currentDate = new Date('2025-10-15T00:00:00Z');
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useParams: () => ({
+    id: 'mock-group-id',
+  }),
+}));
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(currentDate);
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = MockResizeObserver;
+global.fetch = jest
+  .fn()
+  .mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ owner_id: '1', name: '' }),
+  });
+
+describe('Edit Group Page', () => {
+  beforeAll(() => {
+    global.ResizeObserver = MockResizeObserver;
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ owner_id: '1', name: '' }),
+      });
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    jest.clearAllMocks();
   });
 
-  it('disables past dates correctly', () => {
-    render(
-      <Calendar
-        mode="single"
-        selected={currentDate}
-        onSelect={() => {}}
-        disabled={[{ before: currentDate }]}
-        initialFocus
-      />,
-    );
+  describe('Close (X) button in edit group page', () => {
+    it('renders the X button with the correct href', () => {
+      render(<EditGroupPage />);
 
-    const pastDate = screen.getByText('13');
-    expect(pastDate).toBeDisabled();
+      expect(screen.getByTestId('x-button')).toHaveAttribute(
+        'href',
+        '/dashboard',
+      );
+    });
+  });
 
-    const today = screen.getByText('15');
-    expect(today).not.toBeDisabled();
+  describe('Cancel button in edit group page', () => {
+    it('renders the Cancel button with the correct href', () => {
+      render(<EditGroupPage />);
 
-    const tomorrow = screen.getByText('16');
-    expect(tomorrow).not.toBeDisabled();
+      expect(screen.getByRole('link', { name: /cancel/i })).toHaveAttribute(
+        'href',
+        '/dashboard',
+      );
+    });
+  });
+
+  describe('Calendar component in edit group page', () => {
+    const currentDate = new Date('2025-10-15T00:00:00Z');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(currentDate);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('disables past dates correctly', () => {
+      render(
+        <Calendar
+          mode="single"
+          selected={currentDate}
+          onSelect={() => {}}
+          disabled={[{ before: currentDate }]}
+          initialFocus
+        />,
+      );
+
+      const pastDate = screen.getByText('13');
+      expect(pastDate).toBeDisabled();
+
+      const today = screen.getByText('15');
+      expect(today).not.toBeDisabled();
+
+      const tomorrow = screen.getByText('16');
+      expect(tomorrow).not.toBeDisabled();
+    });
   });
 });

--- a/app/gift-exchanges/[id]/edit/page.tsx
+++ b/app/gift-exchanges/[id]/edit/page.tsx
@@ -16,7 +16,7 @@ import {
 import { Check, ChevronsUpDown, ChevronLeft } from 'lucide-react';
 import { Input } from '@/components/Input/Input';
 import { Button } from '@/components/Button/button';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarIcon, X } from 'lucide-react';
 import { Calendar } from '@/components/Calendar/calendar';
 import {
   Popover,
@@ -74,8 +74,8 @@ const formSchema = z
     group_image: z
       .string()
       .refine((val) => groupImageUrls.includes(val), {
-        message: 'Group Theme Image must be selected',
-      }),
+      message: 'Group Theme Image must be selected',
+    }),
   })
   .refine((data) => data.exchange_date > data.drawing_date, {
     message: 'Exchange Date must be after the Drawing Date',
@@ -192,9 +192,19 @@ export default function EditGroupPage() {
       </div>
       <div className="flex items-center justify-center h-full">
         <div className="bg-white w-full xl:w-1/2 mb-5 flex justify-center align-center rounded flex-col ">
-          <h2 className="font-bold m-5">Edit Secret Santa Page</h2>
+          <div className="flex justify-end m-1.5">
+            <Button variant="ghost" asChild data-testid="x-button">
+              <Link href="/dashboard">
+                <X className="text-black" />
+              </Link>
+            </Button>
+          </div>
+          <h2 className="font-bold mx-5 mb-5">Edit Secret Santa Page</h2>
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="space-y-8 mb-6 md:mb-4"
+            >
               <FormField
                 control={form.control}
                 name="name"
@@ -400,14 +410,21 @@ export default function EditGroupPage() {
                   </FormItem>
                 )}
               />
-              <div className="flex md:justify-start justify-center md:m-5 m-0 w-full">
-                <Button className="m-2" type="submit">
+              <div className="sm:flex sm:justify-center md:justify-end sm:gap-3 mx-3 space-x-2 space-y-2 sm:space-x-0 sm:space-y-0">
+                <Button
+                  variant="secondary"
+                  className="bg-slate-300 whitespace-nowrap"
+                  asChild
+                >
+                  <Link href="/dashboard">Cancel</Link>
+                </Button>
+                <Button className="whitespace-nowrap" type="submit">
                   Save Changes
                 </Button>
                 <Button
                   variant="outline"
                   type="button"
-                  className="border border-red-600 text-red-600 hover:bg-red-600 hover:text-white m-2"
+                  className="border border-red-600 text-red-600 hover:bg-red-600 hover:text-white whitespace-nowrap"
                   onClick={deleteGiftExchange}
                 >
                   Delete Group


### PR DESCRIPTION
## Description

### Before: 
Navigating away from the "Edit Group" page was unintuitive, with only the "< Back to Dashboard" link and no "Cancel" button.

### After: 
There are now 2 additional, more conventional ways to navigate back to the dashboard page: an "X" button in the upper-right corner and a "Cancel" button at the bottom of the page.

<!-- Example: closes #123 -->
 Closes #681
 
## Additional information

This is a follow up to PR #633 which has been merged in and addressed the exact same issue for the "Create Group" page.
 
## Screenshots
<img width="663" height="932" alt="image" src="https://github.com/user-attachments/assets/66d04401-a5c0-4d8b-9230-0fa18ee55235" />

<img width="392" height="923" alt="image" src="https://github.com/user-attachments/assets/eaf6a005-f71a-4f45-80d2-c0528b191679" />

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close (X) button to the group edit page header for quick navigation back to the dashboard.
  * Added a Cancel button alongside the Save Changes option in the footer.

* **Style**
  * Enhanced responsive layout and button alignment for improved usability across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->